### PR TITLE
Revert "Bump Backload from 1.9.3.6 to 2.2.7"

### DIFF
--- a/QNH.Overheid.KernRegister.Beheer/packages.config
+++ b/QNH.Overheid.KernRegister.Beheer/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net451" />
-  <package id="Backload" version="2.2.7" targetFramework="net451" />
+  <package id="Backload" version="1.9.3.6" targetFramework="net451" />
   <package id="bootstrap" version="3.3.4" targetFramework="net451" />
   <package id="Bootstrap.v3.Datetimepicker.CSS" version="4.17.45" targetFramework="net451" />
   <package id="CommonServiceLocator" version="2.0.4" targetFramework="net451" />


### PR DESCRIPTION
Reverts B3Partners/CVnHR-Open-Source#42

kennelijk toch wat meer werk om te upgraden van 1.9 naar 2.x : https://github.com/blackcity/Backload/wiki/Upgrade-and-migration